### PR TITLE
Remove unused pymongo dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ protobuf==4.25.5
 tokenizers>=0.20
 pydantic==2.9.2
 retrying==1.3.4
-pymongo==4.10.1
 python-dotenv==1.0.1
 tiktoken==0.8.0
 dill>=0.3.7


### PR DESCRIPTION
- `Pymongo` conflicts with `motor v3.6.1` in projects using `vectara-agentic` alongside with `motor`.
- `Pymongo` is set as dependency for the package and it is not used across the code.

TODO: make the dependencies versions more flexible not bumped at certain version to prevent conflicts with other packages using other versions of those dependencies.