### PR TITLE
Support response streaming and return response metadata

### DIFF
--- a/vectara_agentic/agent.py
+++ b/vectara_agentic/agent.py
@@ -24,6 +24,7 @@ from llama_index.core.callbacks import CallbackManager, TokenCountingHandler
 from llama_index.core.callbacks.base_handler import BaseCallbackHandler
 from llama_index.agent.openai import OpenAIAgent
 from llama_index.core.memory import ChatMemoryBuffer
+from llama_index.core.chat_engine.types import AgentChatResponse
 
 from .types import AgentType, AgentStatusType, LLMRole, ToolType
 from .utils import get_llm, get_tokenizer_for_model
@@ -405,7 +406,7 @@ class Agent:
         stop_max_attempt_number=3,
         wait_fixed=2000,
     )
-    def chat(self, prompt: str) -> str:
+    def chat(self, prompt: str) -> AgentChatResponse:
         """
         Interact with the agent using a chat prompt.
 
@@ -425,17 +426,16 @@ class Agent:
                 Please provide a well formatted final response to the query.
                 final response:
                 """
-                final_response = str(self.llm.complete(prompt))
-            else:
-                final_response = agent_response.response
+                # Override the response text with the final response and keep metadata
+                agent_response.response = str(self.llm.complete(prompt))
 
             if self.verbose:
                 print(f"Time taken: {time.time() - st}")
             if self.observability_enabled:
                 eval_fcs()
-            return final_response
+            return agent_response
         except Exception as e:
-            return f"Vectara Agentic: encountered an exception ({e}) at ({traceback.format_exc()}), and can't respond."
+            raise ValueError(f"Vectara Agentic: encountered an exception ({e}) at ({traceback.format_exc()}), and can't respond.")
 
     # Serialization methods
 


### PR DESCRIPTION
- Create a wrapper around llama-index's `astream_chat` method to expose through Vectara's agent.
- Edit chat method to return full response with metadata -not only the response text- as the tools called can be used to evaluate the agent trajectory.