### PR TITLE
Return Context on Workflow Error

### DIFF
--- a/vectara_agentic/agent.py
+++ b/vectara_agentic/agent.py
@@ -2,7 +2,7 @@
 This module contains the Agent class for handling different types of agents and their interactions.
 """
 
-from typing import List, Callable, Optional, Dict, Any, Union, Tuple, Type
+from typing import List, Callable, Optional, Dict, Any, Union, Tuple
 import os
 import re
 from datetime import date
@@ -1102,13 +1102,13 @@ class Agent:
                 raise ValueError(f"Failed to map workflow output to model: {e}") from e
 
         except Exception as e:
-            OutputModelOnFail = getattr(workflow.__class__, "OutputModelOnFail", None)
-            if OutputModelOnFail:
-                output = OutputModelOnFail.model_validate(workflow_context)
+            outputs_model_on_fail_cls = getattr(workflow.__class__, "OutputModelOnFail", None)
+            if outputs_model_on_fail_cls:
+                output = outputs_model_on_fail_cls.model_validate(workflow_context)
             else:
                 print(f"Vectara Agentic: Workflow failed with unexpected error: {e}")
                 raise type(e)(str(e)).with_traceback(e.__traceback__)
-            
+
         return output
 
     #

--- a/vectara_agentic/agent.py
+++ b/vectara_agentic/agent.py
@@ -1104,7 +1104,14 @@ class Agent:
         except Exception as e:
             outputs_model_on_fail_cls = getattr(workflow.__class__, "OutputModelOnFail", None)
             if outputs_model_on_fail_cls:
-                output = outputs_model_on_fail_cls.model_validate(workflow_context)
+                model_fields = outputs_model_on_fail_cls.model_fields
+                input_dict = {
+                    key: await workflow_context.get(key, None)
+                    for key in model_fields
+                }
+
+                # return output in the form of workflow.OutputModelOnFail(BaseModel)
+                output = outputs_model_on_fail_cls.model_validate(input_dict)
             else:
                 print(f"Vectara Agentic: Workflow failed with unexpected error: {e}")
                 raise type(e)(str(e)).with_traceback(e.__traceback__)


### PR DESCRIPTION
* Added an optional argument `return_context_on_exception`. If set to True, the Agent `run()` function will return the current `Context` object from the workflow rather than just causing an error.