### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ vectara-agentic includes various other tools from LlamaIndex ToolSpecs:
                     tool_spec_name="KuzuGraphStore",
                 )
     ```
-  * Waii: tools for natural langauge query of a relational database
+  * Waii: tools for natural language query of a relational database
     ```python
     waii_tools = tools_factory.get_llama_index_tools(
                     tool_package_name="waii",


### PR DESCRIPTION
Hey, our tool caught a typo in your repository.

Also, a few typos on your site like 'retrieveal'. Here is your error report:
 https://triplechecker.com/s/VJyUqF/vectara.com

Hope it's helpful!
